### PR TITLE
Bump Go version from 1.16 to 1.18

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,17 +5,15 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.18' ]
 
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v3
+    - name: "Set up Go"
+      uses: actions/setup-go@v4
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: "go.mod"
+        cache: true
 
     - name: Test
       run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,14 @@
 module github.com/wtsi-npg/logshim
 
-go 1.16
+go 1.18
 
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Bump setup-go version from 3 to 4. This provides built-in caching.